### PR TITLE
Allow overriding  flex styles for the main container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,9 +44,9 @@ const Checkbox = (props) => {
   return (
     <label
       style={{
-        ...containerStyle,
         display: "flex",
         alignItems: "center",
+        ...containerStyle,
       }}
       className={containerClassName}
       onClick={(e) => toggle(e)}


### PR DESCRIPTION
In my case, I was not able to override alignItems:center to alignItems:flex-start passing the styles via containerStyle prop.
This change will help to override display and alignItems if needed.

![image](https://user-images.githubusercontent.com/13743319/157661119-ba5c6e1b-dc37-40b4-809f-d41e286b5d24.png)